### PR TITLE
easy custom responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ Documentation
 * `verifierURI` - The URI of the Persona Remote Verification API
   * Default: `https://verifier.login.persona.org/verify`
   * You probably don't want to touch this unless you have a good reason, like testing.
-* `verifyResponse(error, req, res, email)` - function to generate response for verify route
-  * Default: see _Verify rout_, below, for successess and failure responses
+* `verifyResponse(error, req, res, email)` - Function to generate response for verify route
+  * Default: see _Verify route_, below, for successess and failure responses
   * `error` will be a string suitable for display (the "reason" attribute in the default implementation), if an error occurs
   * `req, res` are the request and response objects
   * `email` is a string containing the email, and will exist if there is not an error
-* `logoutResponse(error, req, res)` - function to generate response for logout route
+* `logoutResponse(error, req, res)` - Function to generate response for logout route
   * Default: see _Logout route_, below, for response
   * `error` will be a string suitable for display, if an error occurs
   * `req, res` are the request and response objects

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ Documentation
 * `verifierURI` - The URI of the Persona Remote Verification API
   * Default: `https://verifier.login.persona.org/verify`
   * You probably don't want to touch this unless you have a good reason, like testing.
+* `verifyResponse(error, req, res, email)` - function to generate response for verify route
+  * Default: see _Verify rout_, below, for successess and failure responses
+  * `error` will be a string suitable for display (the "reason" attribute in the default implementation), if an error occurs
+  * `req, res` are the request and response objects
+  * `email` is a string containing the email, and will exist if there is not an error
+* `logoutResponse(error, req, res)` - function to generate response for logout route
+  * Default: see _Logout route_, below, for response
+  * `error` will be a string suitable for display, if an error occurs
+  * `req, res` are the request and response objects
 
 ### Verify route
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(app, options) {
 
   var personaOpts = {};
   Object.keys(defaultOptions).forEach(function(key) {
-    if (typeof options[key] === "string") {
+    if (typeof options[key] === "string" || typeof options[key] === "function") {
       personaOpts[key] = options[key];
     } else {
       personaOpts[key] = defaultOptions[key];

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(app, options) {
 
   var personaOpts = {};
   Object.keys(defaultOptions).forEach(function(key) {
-    if (typeof options[key] === "string" || typeof options[key] === "function") {
+    if (typeof options[key] === typeof defaultOptions[key]) {
       personaOpts[key] = options[key];
     } else {
       personaOpts[key] = defaultOptions[key];

--- a/index.js
+++ b/index.js
@@ -8,7 +8,25 @@ var defaultOptions = {
   logoutPath: "/persona/logout",
   sessionKey: "email",
   verifierURI: "https://verifier.login.persona.org/verify",
-  verifyPath: "/persona/verify"
+  verifyPath: "/persona/verify",
+  verifyResponse: function(error, req, res, email) {
+    var out;
+    if (error) {
+      out = { status: "failure", reason: error };
+    } else {
+      out = { status: "okay", email: email };
+    }
+    res.json(out);
+  },
+  logoutResponse: function(error, req, res) {
+    var out;
+    if (error) {
+      out = { status: "failure", reason: error };
+    } else {
+      out = { status: "okay" };
+    }
+    res.json(out);
+  }
 };
 
 module.exports = function(app, options) {
@@ -34,10 +52,7 @@ module.exports = function(app, options) {
       var body = "";
 
       verifierRes.on("error", function(error) {
-        res.json({
-          status: "failure",
-          reason: "Server-side exception"
-        });
+        personaOpts.verifyResponse("Server-side exception", req, res);
       });
 
       verifierRes.on("data", function(chunk) {
@@ -56,31 +71,19 @@ module.exports = function(app, options) {
               req.session[personaOpts.sessionKey] = response.email;
             }
 
-            res.json({
-              status: "okay",
-              email: response.email
-            });
+            personaOpts.verifyResponse(null, req, res, response.email);
           } else {
-            res.json({
-              status: "failure",
-              reason: response.reason
-            });
+            personaOpts.verifyResponse(response.reason, req, res);
           }
 
         } catch (e) {
-          res.json({
-            status: "failure",
-            reason: "Server-side exception"
-          });
+          personaOpts.verifyResponse("Server-side exception", req, res);
         }
       });
     });
     // SSL validation can fail, which will be thrown here
     vreq.on("error", function(error) {
-      res.json({
-        status: "failure",
-        reason: "Server-side exception"
-      });
+      personaOpts.verifyResponse("Server-side exception", req, res);
     });
     vreq.setHeader("Content-Type", "application/json");
     var data = JSON.stringify({
@@ -96,8 +99,6 @@ module.exports = function(app, options) {
       req.session[personaOpts.sessionKey] = null;
     }
 
-    res.json({
-      status: "okay"
-    });
+    personaOpts.logoutResponse(null, req, res);
   });
 };

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -72,19 +72,21 @@ test("no default options", function(t) {
     audience: audience,
     verifyPath: "/browserid/verify",
     logoutPath: "/browserid/logout",
-    sessionKey: "user"
+    sessionKey: "user",
+    verifyResponse: function (error, req, res, email) { res.json({ error: error, email: email }); },
+    logoutResponse: function (error, req, res) { res.json({error: error}); }
   }, function(err, app) {
     common.getAssertionFor(audience, function(err, assertionData) {
       var host = "http://localhost:" + app.address().port;
       var localVerifier = host + "/browserid/verify";
 
       common.verifyAssertion(localVerifier, assertionData.assertion, function(err, verifiedData) {
-        t.equal(verifiedData.status, "okay");
+        t.equal(verifiedData.error, null);
         t.equal(verifiedData.email, assertionData.email);
         common.getSessionData(host + "/session", function(err, body) {
           t.equal(body.user, assertionData.email);
           common.logout(host + "/browserid/logout", function(err, body) {
-            t.equal(body.status, "okay");
+            t.equal(body.error, null);
             common.getSessionData(host + "/session", function(err, body) {
               t.equal(body.user, null);
               t.end();


### PR DESCRIPTION
verifyResponse is now called to generate the response to the verify
route. Default response is identical to old response. It can now be
overridden in the options.

logoutResponse is now called to generate the response to the logout
route. Default response is identical to old response. It can now be
overridden in the options.

this is useful for people who want to send custom information with their login response (such as user object from database), or for people who already have a front-end that expects a specific format from the server.
